### PR TITLE
Run TraceR with a dfly network on the stencil4d-otf example on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     packages:
       - libtool-bin
       - libmpich-dev
+      - mpich
 
 install:
   # Install ROSS

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,3 +50,5 @@ script:
   - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
   - cd ../utils
   - make
+  - mpiexec --help
+  - mpirun --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 script:
   - cd tracer
   - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
-  - make install
+  - make install PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
   - cd ../utils
   - make
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,12 @@ install:
     export PATH=$PATH:${TRAVIS_BUILD_DIR}/ci-deps/OTF2/bin
     
 script:
-  - cd tracer
+  - pushd tracer
   - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
   - make install PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
   - cd ../utils
   - make
+  - popd
   - |
     pushd examples/stencil4d-otf
     mpirun -np 2 ${TRAVIS_BUILD_DIR}/install-test/bin/traceR --sync=3 -- ../conf/dfly.conf tracer_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ install:
 script:
   - cd tracer
   - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
+  - make install
   - cd ../utils
   - make
-  - make install
   - |
     pushd examples/stencil4d-otf
     mpirun -np 2 ${TRAVIS_BUILD_DIR}/install-test/bin/traceR --sync=3 -- ../conf/dfly.conf tracer_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,8 @@ script:
   - make all PREFIX=${TRAVIS_BUILD_DIR}/install-test CXX=mpicc CXX=mpicxx ROSS_DIR="${TRAVIS_BUILD_DIR}/ci-deps/ROSS" CODES_DIR="${TRAVIS_BUILD_DIR}/ci-deps/CODES" SELECT_TRACE="-DTRACER_OTF_TRACES=1"
   - cd ../utils
   - make
-  - mpiexec --help
-  - mpirun --help
+  - make install
+  - |
+    pushd examples/stencil4d-otf
+    mpirun -np 2 ${TRAVIS_BUILD_DIR}/install-test/bin/traceR --sync=3 -- ../conf/dfly.conf tracer_config
+    popd


### PR DESCRIPTION
To get tests working on Travis:
* Run traceR using --lp-io-dir=tests/output/test-output-dfly folder so comparison script will work
* Run traceR for each of the 4 network types
* Run result checking script for each traceR run